### PR TITLE
feat(roster): add Nurse Roster SPA with auto-load, dialog, and past date protection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 exclude: "node_modules|.git"
-default_stages: [pre-commit, pre-push, manual]
+default_stages: [pre-commit, manual]
 fail_fast: false
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         files: "hms_tz.*"
@@ -26,7 +26,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ["--profile", "black", "--line-length", "120"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: "node_modules|.git"
-default_stages: [commit, push, manual]
+default_stages: [pre-commit, pre-push, manual]
 fail_fast: false
 
 repos:

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -18,8 +18,8 @@ declare module 'vue' {
     PaymentDialog: typeof import('./src/components/appointments/PaymentDialog.vue')['default']
     PractitionerCard: typeof import('./src/components/appointments/PractitionerCard.vue')['default']
     Print: typeof import('./src/components/controls/Print.vue')['default']
+    RosterCell: typeof import('./src/components/roster/RosterCell.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
-    TestComponent: typeof import('./src/components/TestComponent.vue')['default']
   }
 }

--- a/frontend/src/components/roster/RosterCell.vue
+++ b/frontend/src/components/roster/RosterCell.vue
@@ -1,0 +1,312 @@
+<template>
+  <td
+    class="relative border-b px-1 py-1 text-center"
+    :class="cellClasses"
+    @click="handleCellClick"
+  >
+    <!-- Existing assignment (read-only pill) -->
+    <div
+      v-if="assignment && !showDialog"
+      class="flex items-center justify-center gap-1"
+    >
+      <span
+        class="inline-flex max-w-[100px] items-center truncate rounded-full px-2 py-1 text-xs font-medium"
+        :class="pillClasses"
+        :title="displayValue"
+      >
+        {{ displayValue }}
+      </span>
+      <!-- Edit button: only shown for future/today dates -->
+      <button
+        v-if="!isPastDate"
+        class="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-500 shadow-sm hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
+        @click.stop="openEditDialog"
+        title="Edit assignment"
+      >
+        <svg
+          class="h-3.5 w-3.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+          />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Empty cell (+): only clickable for future/today dates -->
+    <div
+      v-else-if="!assignment && !showDialog"
+      class="flex h-8 items-center justify-center rounded border border-dashed transition-colors"
+      :class="
+        isPastDate
+          ? 'border-gray-100 text-gray-200'
+          : 'border-gray-200 text-gray-400 hover:border-blue-400 hover:bg-blue-50/50 hover:text-blue-500'
+      "
+    >
+      <svg
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M12 4v16m8-8H4"
+        />
+      </svg>
+    </div>
+
+    <!-- Assignment Dialog -->
+    <Dialog
+      :options="{
+        title: assignment ? 'Edit Assignment' : 'New Assignment',
+        size: 'sm',
+        actions: dialogActions,
+      }"
+      v-model="showDialog"
+      @close="cancelEdit"
+    >
+      <template #body-content>
+        <div class="flex flex-col gap-4">
+          <!-- Nurse & Date info -->
+          <div
+            class="flex items-center gap-3 rounded-lg bg-gray-50 px-3 py-2"
+          >
+            <div class="text-sm">
+              <span class="text-gray-500">Nurse:</span>
+              <span class="ml-1 font-medium text-gray-800">{{
+                nurse
+              }}</span>
+            </div>
+            <div class="text-sm">
+              <span class="text-gray-500">Date:</span>
+              <span class="ml-1 font-medium text-gray-800">{{ date }}</span>
+            </div>
+          </div>
+
+          <!-- Assignment Based On -->
+          <div>
+            <FormControl
+              type="select"
+              label="Assignment Based On"
+              :options="assignBasedOnOptions"
+              v-model="editAssignBasedOn"
+            />
+          </div>
+
+          <!-- Service Unit Type (searchable autocomplete) -->
+          <div v-if="editAssignBasedOn === 'Service Unit Type'">
+            <FormControl
+              type="autocomplete"
+              label="Service Unit Type"
+              :options="serviceUnitTypeOptions"
+              v-model="selectedServiceUnitType"
+              placeholder="Search service unit type..."
+            />
+          </div>
+
+          <!-- Service Unit (searchable autocomplete) -->
+          <div v-if="editAssignBasedOn === 'Service Unit'">
+            <FormControl
+              type="autocomplete"
+              label="Service Unit"
+              :options="serviceUnitOptions"
+              v-model="selectedServiceUnit"
+              placeholder="Search service unit..."
+            />
+          </div>
+
+          <!-- Remove button for existing assignments -->
+          <div v-if="assignment && assignment.name" class="border-t pt-3">
+            <Button
+              variant="subtle"
+              theme="red"
+              class="w-full"
+              @click="removeAssignment"
+            >
+              <template #prefix>
+                <svg
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </template>
+              Remove Assignment
+            </Button>
+          </div>
+        </div>
+      </template>
+    </Dialog>
+  </td>
+</template>
+
+<script setup>
+import { computed, ref } from "vue";
+
+const props = defineProps({
+  nurse: { type: String, required: true },
+  date: { type: String, required: true },
+  isWeekend: { type: Boolean, default: false },
+  isPastDate: { type: Boolean, default: false },
+  assignment: { type: Object, default: null },
+  serviceUnitTypes: { type: Array, default: () => [] },
+  serviceUnits: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["assign", "edit", "remove"]);
+
+const showDialog = ref(false);
+const editAssignBasedOn = ref("Service Unit Type");
+const selectedServiceUnitType = ref(null);
+const selectedServiceUnit = ref(null);
+
+const assignBasedOnOptions = [
+  { label: "Service Unit Type", value: "Service Unit Type" },
+  { label: "Service Unit", value: "Service Unit" },
+];
+
+const displayValue = computed(() => {
+  if (!props.assignment) return "";
+  if (props.assignment.assign_based_on === "Service Unit") {
+    return props.assignment.service_unit || "";
+  }
+  return props.assignment.service_unit_type || "";
+});
+
+// Options formatted for autocomplete
+const serviceUnitTypeOptions = computed(() =>
+  props.serviceUnitTypes.map((s) => ({ label: s, value: s })),
+);
+
+const serviceUnitOptions = computed(() =>
+  props.serviceUnits.map((s) => ({
+    label: s.name,
+    value: s.name,
+  })),
+);
+
+// The currently selected value string
+const currentEditValue = computed(() => {
+  if (editAssignBasedOn.value === "Service Unit Type") {
+    return selectedServiceUnitType.value?.value || "";
+  }
+  return selectedServiceUnit.value?.value || "";
+});
+
+const pillClasses = computed(() => {
+  if (props.assignment?._pending) return "bg-yellow-100 text-yellow-800";
+  return "bg-blue-100 text-blue-800";
+});
+
+const cellClasses = computed(() => ({
+  "bg-orange-50/50": props.isWeekend && !showDialog.value,
+  "cursor-pointer": !showDialog.value && !props.assignment && !props.isPastDate,
+  "bg-blue-50/30": props.assignment && !props.assignment._pending,
+  "bg-yellow-50/50": props.assignment?._pending,
+}));
+
+const dialogActions = computed(() => [
+  {
+    label: "Cancel",
+    variant: "subtle",
+    onClick: () => cancelEdit(),
+  },
+  {
+    label: props.assignment ? "Update" : "Assign",
+    variant: "solid",
+    disabled: !currentEditValue.value,
+    onClick: () => confirmEdit(),
+  },
+]);
+
+function handleCellClick() {
+  // Do not allow opening dialog for past dates
+  if (props.isPastDate) return;
+  if (!props.assignment && !showDialog.value) {
+    openNewDialog();
+  }
+}
+
+function openNewDialog() {
+  editAssignBasedOn.value = "Service Unit Type";
+  selectedServiceUnitType.value = null;
+  selectedServiceUnit.value = null;
+  showDialog.value = true;
+}
+
+function openEditDialog() {
+  // Do not allow editing past dates
+  if (props.isPastDate) return;
+
+  if (props.assignment) {
+    editAssignBasedOn.value =
+      props.assignment.assign_based_on || "Service Unit Type";
+    if (props.assignment.assign_based_on === "Service Unit") {
+      const val = props.assignment.service_unit || "";
+      selectedServiceUnit.value = val ? { label: val, value: val } : null;
+      selectedServiceUnitType.value = null;
+    } else {
+      const val = props.assignment.service_unit_type || "";
+      selectedServiceUnitType.value = val
+        ? { label: val, value: val }
+        : null;
+      selectedServiceUnit.value = null;
+    }
+  }
+  showDialog.value = true;
+}
+
+function confirmEdit() {
+  const val = currentEditValue.value;
+  if (!val) return;
+
+  if (props.assignment?.name) {
+    emit("edit", {
+      nurse: props.nurse,
+      date: props.date,
+      assignBasedOn: editAssignBasedOn.value,
+      value: val,
+      existingName: props.assignment.name,
+    });
+  } else {
+    emit("assign", {
+      nurse: props.nurse,
+      date: props.date,
+      assignBasedOn: editAssignBasedOn.value,
+      value: val,
+    });
+  }
+  showDialog.value = false;
+}
+
+function cancelEdit() {
+  showDialog.value = false;
+  selectedServiceUnitType.value = null;
+  selectedServiceUnit.value = null;
+}
+
+function removeAssignment() {
+  emit("remove", {
+    nurse: props.nurse,
+    date: props.date,
+    existingName: props.assignment?.name || props.assignment?.existing_name,
+  });
+  showDialog.value = false;
+}
+</script>

--- a/frontend/src/pages/NurseRoster.vue
+++ b/frontend/src/pages/NurseRoster.vue
@@ -1,0 +1,398 @@
+<template>
+  <div class="flex h-screen w-screen overflow-hidden">
+    <!-- Sidebar -->
+    <div
+      class="flex h-full flex-col border-r bg-gray-50"
+      :class="isSidebarCollapsed ? 'w-12' : 'w-[220px]'"
+    >
+      <!-- Logo/Brand area -->
+      <div class="flex items-center gap-2 border-b px-3 py-3">
+        <div
+          class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-blue-600 text-white"
+        >
+          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+            />
+          </svg>
+        </div>
+        <span
+          v-if="!isSidebarCollapsed"
+          class="truncate text-sm font-semibold text-gray-800"
+        >
+          HMS TZ
+        </span>
+      </div>
+
+      <!-- Nav links -->
+      <nav class="flex flex-1 flex-col gap-0.5 p-2">
+        <button
+          class="flex h-8 items-center gap-2 rounded-md bg-blue-100 px-2 text-sm font-medium text-blue-700"
+        >
+          <svg
+            class="h-4 w-4 shrink-0 text-blue-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          <span v-if="!isSidebarCollapsed">Nurse Roster</span>
+        </button>
+        <button
+          class="flex h-8 items-center gap-2 rounded-md px-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+          @click="goToNursingSchedule"
+        >
+          <svg
+            class="h-4 w-4 shrink-0 text-gray-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
+          </svg>
+          <span v-if="!isSidebarCollapsed">Nursing Schedule</span>
+        </button>
+      </nav>
+
+      <!-- Collapse toggle -->
+      <div class="border-t p-2">
+        <button
+          class="flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm text-gray-500 hover:bg-gray-200"
+          @click="isSidebarCollapsed = !isSidebarCollapsed"
+        >
+          <svg
+            class="h-4 w-4 shrink-0 transition-transform duration-300"
+            :class="{ 'rotate-180': isSidebarCollapsed }"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
+            />
+          </svg>
+          <span v-if="!isSidebarCollapsed">Collapse</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Main content -->
+    <div class="flex flex-1 flex-col overflow-hidden">
+      <!-- Header (centered) -->
+      <div class="border-b bg-white px-6 py-4">
+        <h1 class="text-center text-xl font-semibold text-gray-900">
+          Nurse Roster
+        </h1>
+        <p class="mt-1 text-center text-sm" style="color: #60a5fa">
+          Assign nurses to wards and rooms across dates
+        </p>
+      </div>
+
+      <!-- Filter Bar (centered, reordered: Company → Frequency → Start Date → End Date) -->
+      <div class="border-b bg-white px-6 py-4">
+        <div class="flex flex-wrap items-end justify-center gap-4">
+          <div class="w-52">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              Company
+            </label>
+            <FormControl
+              type="autocomplete"
+              :options="companyOptions"
+              v-model="companyModel"
+              placeholder="Select Company"
+            />
+          </div>
+          <div class="w-40">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              Frequency
+            </label>
+            <FormControl
+              type="select"
+              :options="frequencyOptions"
+              v-model="store.frequency"
+              @change="store.calculateEndDate()"
+            />
+          </div>
+          <div class="w-40">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              Start Date
+            </label>
+            <FormControl
+              type="date"
+              v-model="store.startDate"
+              @change="store.calculateEndDate()"
+            />
+          </div>
+          <div class="w-40">
+            <label class="mb-1 block text-xs font-medium text-gray-600">
+              End Date
+            </label>
+            <FormControl
+              type="date"
+              :modelValue="store.endDate"
+              disabled
+              class="bg-gray-50"
+            />
+          </div>
+          <!-- Loading indicator inline -->
+          <div v-if="store.isLoading" class="flex items-center pb-1">
+            <LoadingIndicator class="h-5 w-5" />
+          </div>
+        </div>
+      </div>
+
+      <!-- Scrollable grid section -->
+      <div class="flex-1 overflow-auto">
+        <!-- Grid -->
+        <div class="p-6" v-if="store.nurses.length">
+          <div class="overflow-x-auto rounded-lg border bg-white shadow-sm">
+            <table class="w-full border-collapse">
+              <thead>
+                <tr>
+                  <th
+                    class="sticky left-0 z-10 min-w-[180px] border-b border-r bg-gray-50 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600"
+                  >
+                    Nurse
+                  </th>
+                  <th
+                    v-for="col in store.dateColumns"
+                    :key="col.date"
+                    class="min-w-[120px] border-b px-2 py-3 text-center text-xs font-semibold uppercase tracking-wider"
+                    :class="
+                      col.isWeekend
+                        ? 'bg-orange-50 text-orange-700'
+                        : 'bg-gray-50 text-gray-600'
+                    "
+                  >
+                    {{ col.label }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="nurse in store.nurses"
+                  :key="nurse.name"
+                  class="group hover:bg-gray-50/50"
+                >
+                  <!-- Nurse name (sticky left) -->
+                  <td
+                    class="sticky left-0 z-10 border-b border-r bg-white px-4 py-2 group-hover:bg-gray-50"
+                  >
+                    <div class="text-sm font-medium text-gray-900">
+                      {{ nurse.practitioner_name }}
+                    </div>
+                  </td>
+
+                  <!-- Date cells -->
+                  <RosterCell
+                    v-for="col in store.dateColumns"
+                    :key="`${nurse.name}-${col.date}`"
+                    :nurse="nurse.name"
+                    :date="col.date"
+                    :is-weekend="col.isWeekend"
+                    :is-past-date="isDatePast(col.date)"
+                    :assignment="store.getAssignment(nurse.name, col.date)"
+                    :service-unit-types="store.serviceUnitTypes"
+                    :service-units="store.serviceUnits"
+                    @assign="handleAssign"
+                    @edit="handleEdit"
+                    @remove="handleRemove"
+                  />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Empty state -->
+        <div
+          v-else-if="!store.isLoading"
+          class="flex flex-col items-center justify-center px-6 py-20"
+        >
+          <div class="text-center">
+            <svg
+              class="mx-auto h-12 w-12 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            <h3 class="mt-4 text-sm font-medium text-gray-900">
+              No roster loaded
+            </h3>
+            <p class="mt-1 text-sm text-gray-500">
+              Select company, start date and frequency to load the roster
+              automatically.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Save bar (fixed at bottom of main content) -->
+      <div
+        v-if="store.hasPendingChanges()"
+        class="border-t bg-white px-6 py-3 shadow-lg"
+      >
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-gray-600">
+            <span class="font-semibold text-blue-600">{{
+              store.pendingChanges.length
+            }}</span>
+            unsaved change(s)
+          </p>
+          <div class="flex gap-3">
+            <Button variant="subtle" @click="store.pendingChanges = []">
+              Discard
+            </Button>
+            <Button
+              variant="solid"
+              :loading="store.isSaving"
+              @click="store.saveRoster()"
+            >
+              Save Changes
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import dayjs from "dayjs";
+import { createResource } from "frappe-ui";
+import { computed, onMounted, ref, watch } from "vue";
+import RosterCell from "@/components/roster/RosterCell.vue";
+import { useRosterStore } from "@/stores/rosterStore";
+
+const store = useRosterStore();
+const isSidebarCollapsed = ref(false);
+
+// Company options
+const companyOptions = ref([]);
+const companyResource = createResource({
+  url: "frappe.client.get_list",
+  params: {
+    doctype: "Company",
+    fields: ["name"],
+    order_by: "name asc",
+    limit_page_length: 0,
+  },
+  auto: true,
+  onSuccess(data) {
+    companyOptions.value = data.map((c) => ({
+      label: c.name,
+      value: c.name,
+    }));
+  },
+});
+
+const frequencyOptions = [
+  { label: "Daily", value: "Daily" },
+  { label: "Weekly", value: "Weekly" },
+  { label: "Monthly", value: "Monthly" },
+  { label: "Quarterly", value: "Quarterly" },
+  { label: "Bi-Yearly", value: "Bi-Yearly" },
+  { label: "Yearly", value: "Yearly" },
+];
+
+// v-model computed for autocomplete: converts between option object and string
+const companyModel = computed({
+  get() {
+    if (!store.company) return null;
+    return { label: store.company, value: store.company };
+  },
+  set(option) {
+    if (option && typeof option === "object") {
+      store.company = option.value || option.label || "";
+    } else {
+      store.company = option || "";
+    }
+  },
+});
+
+// Check if a date is in the past (before today)
+function isDatePast(dateStr) {
+  return dayjs(dateStr).isBefore(dayjs(), "day");
+}
+
+// Auto-load roster when all fields are filled
+watch(
+  () => [store.company, store.startDate, store.frequency, store.endDate],
+  () => {
+    if (store.company && store.startDate && store.frequency && store.endDate) {
+      store.loadRoster();
+    }
+  },
+);
+
+function goToNursingSchedule() {
+  window.location.href = "/app/nursing-schedule";
+}
+
+// Try to get params from URL
+onMounted(() => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("company")) store.company = params.get("company");
+  if (params.get("start_date")) store.startDate = params.get("start_date");
+  if (params.get("frequency")) store.frequency = params.get("frequency");
+  if (store.startDate && store.frequency) {
+    store.calculateEndDate();
+  }
+});
+
+function handleAssign({ nurse, date, assignBasedOn, value }) {
+  store.addPendingChange({
+    nurse,
+    assignment_date: date,
+    assign_based_on: assignBasedOn,
+    service_unit_type: assignBasedOn === "Service Unit Type" ? value : "",
+    service_unit: assignBasedOn === "Service Unit" ? value : "",
+    action: "add",
+  });
+}
+
+function handleEdit({ nurse, date, assignBasedOn, value, existingName }) {
+  store.addPendingChange({
+    nurse,
+    assignment_date: date,
+    assign_based_on: assignBasedOn,
+    service_unit_type: assignBasedOn === "Service Unit Type" ? value : "",
+    service_unit: assignBasedOn === "Service Unit" ? value : "",
+    existing_name: existingName,
+    action: "edit",
+  });
+}
+
+function handleRemove({ nurse, date, existingName }) {
+  store.addPendingChange({
+    nurse,
+    assignment_date: date,
+    existing_name: existingName,
+    action: "remove",
+  });
+}
+</script>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -14,6 +14,11 @@ const routes = [
     component: () => import("@/pages/Appointments.vue"),
   },
   {
+    path: "/nurse-roster",
+    name: "NurseRoster",
+    component: () => import("@/pages/NurseRoster.vue"),
+  },
+  {
     name: "Login",
     path: "/account/login",
     component: () => import("@/pages/Login.vue"),

--- a/frontend/src/stores/rosterStore.js
+++ b/frontend/src/stores/rosterStore.js
@@ -1,0 +1,202 @@
+import dayjs from "dayjs";
+import { createResource } from "frappe-ui";
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+
+export const useRosterStore = defineStore("roster", () => {
+  // Filter state
+  const company = ref("");
+  const startDate = ref("");
+  const frequency = ref("Weekly");
+  const endDate = ref("");
+
+  // Data state
+  const nurses = ref([]);
+  const assignments = ref([]);
+  const serviceUnitTypes = ref([]);
+  const serviceUnits = ref([]);
+
+  // Pending changes (tracked before save)
+  const pendingChanges = ref([]);
+
+  // Loading state
+  const isLoading = ref(false);
+  const isSaving = ref(false);
+
+  // Date columns
+  const dateColumns = computed(() => {
+    if (!startDate.value || !endDate.value) return [];
+    const cols = [];
+    let current = dayjs(startDate.value);
+    const end = dayjs(endDate.value);
+    while (current.isBefore(end) || current.isSame(end, "day")) {
+      cols.push({
+        date: current.format("YYYY-MM-DD"),
+        label: current.format("ddd DD"),
+        isWeekend:
+          current.day() === 0 || current.day() === 6,
+      });
+      current = current.add(1, "day");
+    }
+    return cols;
+  });
+
+  // Build a lookup map: nurse -> date -> assignment
+  const assignmentMap = computed(() => {
+    const map = {};
+    for (const a of assignments.value) {
+      const key = `${a.nurse}|${a.assignment_date}`;
+      map[key] = a;
+    }
+    // Overlay pending changes
+    for (const change of pendingChanges.value) {
+      const key = `${change.nurse}|${change.assignment_date}`;
+      if (change.action === "remove") {
+        delete map[key];
+      } else {
+        map[key] = { ...map[key], ...change, _pending: true };
+      }
+    }
+    return map;
+  });
+
+  function getAssignment(nurse, date) {
+    return assignmentMap.value[`${nurse}|${date}`] || null;
+  }
+
+  // Calculate end date
+  function calculateEndDate() {
+    if (!startDate.value || !frequency.value) {
+      endDate.value = "";
+      return;
+    }
+    const frequencyMap = {
+      Daily: { days: 0 },
+      Weekly: { days: 6 },
+      Monthly: { months: 1 },
+      Quarterly: { months: 3 },
+      "Bi-Yearly": { months: 6 },
+      Yearly: { months: 12 },
+    };
+    const offset = frequencyMap[frequency.value];
+    if (!offset) return;
+
+    if (offset.days !== undefined) {
+      endDate.value = dayjs(startDate.value)
+        .add(offset.days, "day")
+        .format("YYYY-MM-DD");
+    } else {
+      endDate.value = dayjs(startDate.value)
+        .add(offset.months, "month")
+        .subtract(1, "day")
+        .format("YYYY-MM-DD");
+    }
+  }
+
+  // API resources
+  const rosterDataResource = createResource({
+    url: "hms_tz.hms_tz.doctype.nursing_schedule.roster.get_roster_data",
+    onSuccess(data) {
+      nurses.value = data.nurses || [];
+      assignments.value = data.assignments || [];
+      pendingChanges.value = [];
+      isLoading.value = false;
+    },
+    onError() {
+      isLoading.value = false;
+    },
+  });
+
+  const serviceOptionsResource = createResource({
+    url: "hms_tz.hms_tz.doctype.nursing_schedule.roster.get_service_options",
+    onSuccess(data) {
+      serviceUnitTypes.value = data.service_unit_types || [];
+      serviceUnits.value = data.service_units || [];
+    },
+  });
+
+  const saveResource = createResource({
+    url: "hms_tz.hms_tz.doctype.nursing_schedule.roster.save_roster_assignments",
+    onSuccess() {
+      isSaving.value = false;
+      // Reload after save
+      loadRoster();
+    },
+    onError() {
+      isSaving.value = false;
+    },
+  });
+
+  function loadRoster() {
+    if (!company.value || !startDate.value || !endDate.value) return;
+    isLoading.value = true;
+    rosterDataResource.submit({
+      company: company.value,
+      start_date: startDate.value,
+      end_date: endDate.value,
+    });
+    serviceOptionsResource.submit({
+      company: company.value,
+    });
+  }
+
+  function addPendingChange(change) {
+    // Remove any existing pending change for same nurse+date
+    pendingChanges.value = pendingChanges.value.filter(
+      (c) =>
+        !(
+          c.nurse === change.nurse &&
+          c.assignment_date === change.assignment_date
+        ),
+    );
+    pendingChanges.value.push(change);
+  }
+
+  function removePendingChange(nurse, date) {
+    pendingChanges.value = pendingChanges.value.filter(
+      (c) => !(c.nurse === nurse && c.assignment_date === date),
+    );
+  }
+
+  function hasPendingChanges() {
+    return pendingChanges.value.length > 0;
+  }
+
+  function saveRoster() {
+    if (!pendingChanges.value.length) return;
+    isSaving.value = true;
+    saveResource.submit({
+      company: company.value,
+      start_date: startDate.value,
+      end_date: endDate.value,
+      frequency: frequency.value,
+      assignments: JSON.stringify(pendingChanges.value),
+    });
+  }
+
+  return {
+    // State
+    company,
+    startDate,
+    frequency,
+    endDate,
+    nurses,
+    assignments,
+    serviceUnitTypes,
+    serviceUnits,
+    pendingChanges,
+    isLoading,
+    isSaving,
+    // Computed
+    dateColumns,
+    assignmentMap,
+    // Methods
+    getAssignment,
+    calculateEndDate,
+    loadRoster,
+    addPendingChange,
+    removePendingChange,
+    hasPendingChanges,
+    saveRoster,
+  };
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
       jinjaBootData: true,
       lucideIcons: true,
       buildConfig: {
-        indexHtmlPath: "../<app-name>/www/frontend.html",
+        indexHtmlPath: "../hms_tz/www/frontend.html",
         emptyOutDir: true,
         sourcemap: true,
       },
@@ -20,7 +20,7 @@ export default defineConfig({
   ],
   build: {
     chunkSizeWarningLimit: 1500,
-    outDir: "../<app-name>/public/frontend",
+    outDir: "../hms_tz/public/frontend",
     emptyOutDir: true,
     target: "es2015",
     sourcemap: true,

--- a/hms_tz/hms_tz/doctype/episode_of_care/episode_of_care.js
+++ b/hms_tz/hms_tz/doctype/episode_of_care/episode_of_care.js
@@ -2,6 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Episode of Care", {
-  // refresh: function(frm) {
-  // }
+  setup: function (frm) {
+    frm.set_query("initiated_by", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+    frm.set_query("primary_practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
 });

--- a/hms_tz/hms_tz/doctype/healthcare_nursing_task/healthcare_nursing_task.js
+++ b/hms_tz/hms_tz/doctype/healthcare_nursing_task/healthcare_nursing_task.js
@@ -2,6 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Healthcare Nursing Task", {
+  setup: function (frm) {
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     frm.set_query("service_unit", function () {
       return {

--- a/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.js
+++ b/hms_tz/hms_tz/doctype/healthcare_referral/healthcare_referral.js
@@ -4,6 +4,9 @@
 frappe.ui.form.on("Healthcare Referral", {
   setup: (frm) => {
     frm.get_field("diagnosis").grid.cannot_add_rows = true;
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
   },
   refresh: (frm) => {
     frm.get_field("diagnosis").grid.cannot_add_rows = true;

--- a/hms_tz/hms_tz/doctype/healthcare_service_order/healthcare_service_order.js
+++ b/hms_tz/hms_tz/doctype/healthcare_service_order/healthcare_service_order.js
@@ -2,6 +2,14 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Healthcare Service Order", {
+  setup: function (frm) {
+    frm.set_query("ordered_by", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+    frm.set_query("referring_practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     frm.set_query("insurance_subscription", function () {
       return {

--- a/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.js
+++ b/hms_tz/hms_tz/doctype/healthcare_service_request/healthcare_service_request.js
@@ -201,4 +201,12 @@ var set_filters = (frm) => {
       },
     };
   });
+
+  frm.set_query("practitioner", () => {
+    return {
+      filters: {
+        practitioner_role: "Doctor",
+      },
+    };
+  });
 };

--- a/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.js
+++ b/hms_tz/hms_tz/doctype/inpatient_record/inpatient_record.js
@@ -82,17 +82,26 @@ frappe.ui.form.on("Inpatient Record", {
       frm.set_df_property("btn_transfer", "hidden", 0);
     }
 
+    frm.set_query("primary_practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/lab_test/lab_test.js
+++ b/hms_tz/hms_tz/doctype/lab_test/lab_test.js
@@ -32,17 +32,26 @@ frappe.ui.form.on("Lab Test", {
   refresh: function (frm) {
     refresh_field("normal_test_items");
     refresh_field("descriptive_test_items");
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
+++ b/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
@@ -1,0 +1,82 @@
+{
+ "actions": [],
+ "creation": "2026-04-04 21:32:36.013090",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "nurse",
+  "nurse_name",
+  "shift_type",
+  "shift_based_on",
+  "column_break_01",
+  "service_unit_type",
+  "service_unit"
+ ],
+ "fields": [
+  {
+   "fieldname": "nurse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Nurse",
+   "options": "Healthcare Practitioner",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "nurse.practitioner_name",
+   "fieldname": "nurse_name",
+   "fieldtype": "Data",
+   "label": "Nurse Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "shift_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Shift Type",
+   "options": "Morning\nAfternoon\nNight\nFull Day",
+   "reqd": 1
+  },
+  {
+   "default": "Service Unit",
+   "fieldname": "shift_based_on",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Shift Based On",
+   "options": "Service Unit Type\nService Unit",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_01",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.shift_based_on=='Service Unit Type'",
+   "fieldname": "service_unit_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Service Unit Type",
+   "options": "Healthcare Service Unit Type"
+  },
+  {
+   "depends_on": "eval:doc.shift_based_on=='Service Unit'",
+   "fieldname": "service_unit",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Service Unit",
+   "options": "Healthcare Service Unit"
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-04 21:36:28.516239",
+ "modified_by": "Administrator",
+ "module": "Hms Tz",
+ "name": "Nurse Schedule Detail",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
+++ b/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
@@ -1,82 +1,82 @@
 {
- "actions": [],
- "creation": "2026-04-04 21:32:36.013090",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "nurse",
-  "nurse_name",
-  "shift_type",
-  "shift_based_on",
-  "column_break_01",
-  "service_unit_type",
-  "service_unit"
- ],
- "fields": [
-  {
-   "fieldname": "nurse",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Nurse",
-   "options": "Healthcare Practitioner",
-   "reqd": 1
-  },
-  {
-   "fetch_from": "nurse.practitioner_name",
-   "fieldname": "nurse_name",
-   "fieldtype": "Data",
-   "label": "Nurse Name",
-   "read_only": 1
-  },
-  {
-   "fieldname": "shift_type",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Shift Type",
-   "options": "Morning\nAfternoon\nNight\nFull Day",
-   "reqd": 1
-  },
-  {
-   "default": "Service Unit",
-   "fieldname": "shift_based_on",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Shift Based On",
-   "options": "Service Unit Type\nService Unit",
-   "reqd": 1
-  },
-  {
-   "fieldname": "column_break_01",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval:doc.shift_based_on=='Service Unit Type'",
-   "fieldname": "service_unit_type",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Service Unit Type",
-   "options": "Healthcare Service Unit Type"
-  },
-  {
-   "depends_on": "eval:doc.shift_based_on=='Service Unit'",
-   "fieldname": "service_unit",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Service Unit",
-   "options": "Healthcare Service Unit"
-  }
- ],
- "istable": 1,
- "links": [],
- "modified": "2026-04-04 21:36:28.516239",
- "modified_by": "Administrator",
- "module": "Hms Tz",
- "name": "Nurse Schedule Detail",
- "owner": "Administrator",
- "permissions": [],
- "row_format": "Dynamic",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+    "actions": [],
+    "creation": "2026-04-04 21:32:36.013090",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "nurse",
+        "nurse_name",
+        "shift_type",
+        "shift_based_on",
+        "column_break_01",
+        "service_unit_type",
+        "service_unit"
+    ],
+    "fields": [
+        {
+            "fieldname": "nurse",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Nurse",
+            "options": "Healthcare Practitioner",
+            "reqd": 1
+        },
+        {
+            "fetch_from": "nurse.practitioner_name",
+            "fieldname": "nurse_name",
+            "fieldtype": "Data",
+            "label": "Nurse Name",
+            "read_only": 1
+        },
+        {
+            "fieldname": "shift_type",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Shift Type",
+            "options": "Morning\nAfternoon\nNight\nFull Day",
+            "reqd": 1
+        },
+        {
+            "default": "Service Unit Type",
+            "fieldname": "shift_based_on",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Shift Based On",
+            "options": "Service Unit Type\nService Unit",
+            "reqd": 1
+        },
+        {
+            "fieldname": "column_break_01",
+            "fieldtype": "Column Break"
+        },
+        {
+            "depends_on": "eval:doc.shift_based_on=='Service Unit Type'",
+            "fieldname": "service_unit_type",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Service Unit Type",
+            "options": "Healthcare Service Unit Type"
+        },
+        {
+            "depends_on": "eval:doc.shift_based_on=='Service Unit'",
+            "fieldname": "service_unit",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Service Unit",
+            "options": "Healthcare Service Unit"
+        }
+    ],
+    "istable": 1,
+    "links": [],
+    "modified": "2026-04-06 13:36:00.000000",
+    "modified_by": "Administrator",
+    "module": "Hms Tz",
+    "name": "Nurse Schedule Detail",
+    "owner": "Administrator",
+    "permissions": [],
+    "row_format": "Dynamic",
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
 }

--- a/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
+++ b/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.json
@@ -7,8 +7,8 @@
     "field_order": [
         "nurse",
         "nurse_name",
-        "shift_type",
-        "shift_based_on",
+        "assignment_date",
+        "assign_based_on",
         "column_break_01",
         "service_unit_type",
         "service_unit"
@@ -30,19 +30,18 @@
             "read_only": 1
         },
         {
-            "fieldname": "shift_type",
-            "fieldtype": "Select",
+            "fieldname": "assignment_date",
+            "fieldtype": "Date",
             "in_list_view": 1,
-            "label": "Shift Type",
-            "options": "Morning\nAfternoon\nNight\nFull Day",
+            "label": "Assignment Date",
             "reqd": 1
         },
         {
             "default": "Service Unit Type",
-            "fieldname": "shift_based_on",
+            "fieldname": "assign_based_on",
             "fieldtype": "Select",
             "in_list_view": 1,
-            "label": "Shift Based On",
+            "label": "Assign Based On",
             "options": "Service Unit Type\nService Unit",
             "reqd": 1
         },
@@ -51,7 +50,7 @@
             "fieldtype": "Column Break"
         },
         {
-            "depends_on": "eval:doc.shift_based_on=='Service Unit Type'",
+            "depends_on": "eval:doc.assign_based_on=='Service Unit Type'",
             "fieldname": "service_unit_type",
             "fieldtype": "Link",
             "in_list_view": 1,
@@ -59,7 +58,7 @@
             "options": "Healthcare Service Unit Type"
         },
         {
-            "depends_on": "eval:doc.shift_based_on=='Service Unit'",
+            "depends_on": "eval:doc.assign_based_on=='Service Unit'",
             "fieldname": "service_unit",
             "fieldtype": "Link",
             "in_list_view": 1,
@@ -69,7 +68,7 @@
     ],
     "istable": 1,
     "links": [],
-    "modified": "2026-04-06 13:36:00.000000",
+    "modified": "2026-04-06 17:30:00.000000",
     "modified_by": "Administrator",
     "module": "Hms Tz",
     "name": "Nurse Schedule Detail",

--- a/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.py
+++ b/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2026, Aakvatech Limited and contributors
 # For license information, please see license.txt
 
-import frappe
 from frappe.model.document import Document
 
 

--- a/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.py
+++ b/hms_tz/hms_tz/doctype/nurse_schedule_detail/nurse_schedule_detail.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Aakvatech Limited and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class NurseScheduleDetail(Document):
+    pass

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -29,6 +29,56 @@ frappe.ui.form.on("Nursing Schedule", {
   frequency: function (frm) {
     calculate_end_date(frm);
   },
+
+  get_nurses: function (frm) {
+    if (!frm.doc.company) {
+      frappe.msgprint(__("Please select a Company first."));
+      return;
+    }
+
+    frappe.call({
+      method:
+        "hms_tz.hms_tz.doctype.nursing_schedule.nursing_schedule.get_nurses",
+      args: {
+        company: frm.doc.company,
+      },
+      freeze: true,
+      freeze_message: __("Fetching nurses..."),
+      callback: function (r) {
+        if (!r.message || r.message.length === 0) {
+          frappe.msgprint(__("No active nurses found for the selected company."));
+          return;
+        }
+
+        // Collect existing nurse names to avoid duplicates
+        const existing_nurses = new Set(
+          (frm.doc.shifts || []).map((row) => row.nurse)
+        );
+
+        let added_count = 0;
+        r.message.forEach(function (nurse) {
+          if (!existing_nurses.has(nurse.name)) {
+            let row = frm.add_child("shifts");
+            row.nurse = nurse.name;
+            row.nurse_name = nurse.practitioner_name;
+            existing_nurses.add(nurse.name);
+            added_count++;
+          }
+        });
+
+        frm.refresh_field("shifts");
+
+        if (added_count > 0) {
+          frappe.show_alert({
+            message: __("{0} nurse(s) added to the schedule.", [added_count]),
+            indicator: "green",
+          });
+        } else {
+          frappe.msgprint(__("All active nurses are already in the schedule."));
+        }
+      },
+    });
+  },
 });
 
 frappe.ui.form.on("Nurse Schedule Detail", {

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -23,21 +23,11 @@ frappe.ui.form.on("Nursing Schedule", {
   },
 
   start_date: function (frm) {
-    if (frm.doc.start_date && frm.doc.end_date) {
-      if (frm.doc.start_date > frm.doc.end_date) {
-        frappe.msgprint(__("Start Date cannot be after End Date."));
-        frm.set_value("start_date", "");
-      }
-    }
+    calculate_end_date(frm);
   },
 
-  end_date: function (frm) {
-    if (frm.doc.start_date && frm.doc.end_date) {
-      if (frm.doc.end_date < frm.doc.start_date) {
-        frappe.msgprint(__("End Date cannot be before Start Date."));
-        frm.set_value("end_date", "");
-      }
-    }
+  frequency: function (frm) {
+    calculate_end_date(frm);
   },
 });
 
@@ -51,3 +41,33 @@ frappe.ui.form.on("Nurse Schedule Detail", {
     }
   },
 });
+
+function calculate_end_date(frm) {
+  if (!frm.doc.start_date || !frm.doc.frequency) {
+    frm.set_value("end_date", "");
+    return;
+  }
+
+  const frequency_map = {
+    Daily: { days: 0 },
+    Weekly: { days: 6 },
+    Monthly: { months: 1 },
+    Quarterly: { months: 3 },
+    "Bi-Yearly": { months: 6 },
+    Yearly: { months: 12 },
+  };
+
+  const offset = frequency_map[frm.doc.frequency];
+  if (!offset) return;
+
+  let end_date;
+  if (offset.days !== undefined) {
+    end_date = frappe.datetime.add_days(frm.doc.start_date, offset.days);
+  } else {
+    // Add months, then subtract 1 day to get the last day of the period
+    end_date = frappe.datetime.add_months(frm.doc.start_date, offset.months);
+    end_date = frappe.datetime.add_days(end_date, -1);
+  }
+
+  frm.set_value("end_date", end_date);
+}

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -46,7 +46,9 @@ frappe.ui.form.on("Nursing Schedule", {
       freeze_message: __("Fetching nurses..."),
       callback: function (r) {
         if (!r.message || r.message.length === 0) {
-          frappe.msgprint(__("No active nurses found for the selected company."));
+          frappe.msgprint(
+            __("No active nurses found for the selected company.")
+          );
           return;
         }
 
@@ -74,7 +76,9 @@ frappe.ui.form.on("Nursing Schedule", {
             indicator: "green",
           });
         } else {
-          frappe.msgprint(__("All active nurses are already in the schedule."));
+          frappe.msgprint(
+            __("All active nurses are already in the schedule.")
+          );
         }
       },
     });

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, Aakvatech Limited and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Nursing Schedule", {
+  setup: function (frm) {
+    // Filter 'nurse' column in child table to only show Nurses
+    frm.set_query("nurse", "shifts", function () {
+      return {
+        filters: {
+          practitioner_role: "Nurse",
+        },
+      };
+    });
+
+    // Filter 'service_unit' and 'service_unit_type' correctly
+    frm.set_query("service_unit", "shifts", function () {
+      return {
+        filters: {
+          is_group: 0,
+        },
+      };
+    });
+  },
+
+  start_date: function (frm) {
+    if (frm.doc.start_date && frm.doc.end_date) {
+      if (frm.doc.start_date > frm.doc.end_date) {
+        frappe.msgprint(__("Start Date cannot be after End Date."));
+        frm.set_value("start_date", "");
+      }
+    }
+  },
+
+  end_date: function (frm) {
+    if (frm.doc.start_date && frm.doc.end_date) {
+      if (frm.doc.end_date < frm.doc.start_date) {
+        frappe.msgprint(__("End Date cannot be before Start Date."));
+        frm.set_value("end_date", "");
+      }
+    }
+  },
+});
+
+frappe.ui.form.on("Nurse Schedule Detail", {
+  shift_based_on: function (frm, cdt, cdn) {
+    let row = locals[cdt][cdn];
+    if (row.shift_based_on === "Service Unit") {
+      frappe.model.set_value(cdt, cdn, "service_unit_type", "");
+    } else {
+      frappe.model.set_value(cdt, cdn, "service_unit", "");
+    }
+  },
+});

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -23,21 +23,61 @@ frappe.ui.form.on("Nursing Schedule", {
   },
 
   start_date: function (frm) {
-    if (frm.doc.start_date && frm.doc.end_date) {
-      if (frm.doc.start_date > frm.doc.end_date) {
-        frappe.msgprint(__("Start Date cannot be after End Date."));
-        frm.set_value("start_date", "");
-      }
-    }
+    calculate_end_date(frm);
   },
 
-  end_date: function (frm) {
-    if (frm.doc.start_date && frm.doc.end_date) {
-      if (frm.doc.end_date < frm.doc.start_date) {
-        frappe.msgprint(__("End Date cannot be before Start Date."));
-        frm.set_value("end_date", "");
-      }
+  frequency: function (frm) {
+    calculate_end_date(frm);
+  },
+
+  get_nurses: function (frm) {
+    if (!frm.doc.company) {
+      frappe.msgprint(__("Please select a Company first."));
+      return;
     }
+
+    frappe.call({
+      method:
+        "hms_tz.hms_tz.doctype.nursing_schedule.nursing_schedule.get_nurses",
+      args: {
+        company: frm.doc.company,
+      },
+      freeze: true,
+      freeze_message: __("Fetching nurses..."),
+      callback: function (r) {
+        if (!r.message || r.message.length === 0) {
+          frappe.msgprint(__("No active nurses found for the selected company."));
+          return;
+        }
+
+        // Collect existing nurse names to avoid duplicates
+        const existing_nurses = new Set(
+          (frm.doc.shifts || []).map((row) => row.nurse)
+        );
+
+        let added_count = 0;
+        r.message.forEach(function (nurse) {
+          if (!existing_nurses.has(nurse.name)) {
+            let row = frm.add_child("shifts");
+            row.nurse = nurse.name;
+            row.nurse_name = nurse.practitioner_name;
+            existing_nurses.add(nurse.name);
+            added_count++;
+          }
+        });
+
+        frm.refresh_field("shifts");
+
+        if (added_count > 0) {
+          frappe.show_alert({
+            message: __("{0} nurse(s) added to the schedule.", [added_count]),
+            indicator: "green",
+          });
+        } else {
+          frappe.msgprint(__("All active nurses are already in the schedule."));
+        }
+      },
+    });
   },
 });
 
@@ -51,3 +91,33 @@ frappe.ui.form.on("Nurse Schedule Detail", {
     }
   },
 });
+
+function calculate_end_date(frm) {
+  if (!frm.doc.start_date || !frm.doc.frequency) {
+    frm.set_value("end_date", "");
+    return;
+  }
+
+  const frequency_map = {
+    Daily: { days: 0 },
+    Weekly: { days: 6 },
+    Monthly: { months: 1 },
+    Quarterly: { months: 3 },
+    "Bi-Yearly": { months: 6 },
+    Yearly: { months: 12 },
+  };
+
+  const offset = frequency_map[frm.doc.frequency];
+  if (!offset) return;
+
+  let end_date;
+  if (offset.days !== undefined) {
+    end_date = frappe.datetime.add_days(frm.doc.start_date, offset.days);
+  } else {
+    // Add months, then subtract 1 day to get the last day of the period
+    end_date = frappe.datetime.add_months(frm.doc.start_date, offset.months);
+    end_date = frappe.datetime.add_days(end_date, -1);
+  }
+
+  frm.set_value("end_date", end_date);
+}

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -62,9 +62,7 @@ frappe.ui.form.on("Nursing Schedule", {
       callback: function (r) {
         if (!r.message || r.message.length === 0) {
           frappe.msgprint(
-            __(
-              "No active nurses found for the selected company."
-            )
+            __("No active nurses found for the selected company.")
           );
           return;
         }
@@ -102,9 +100,7 @@ frappe.ui.form.on("Nursing Schedule", {
           });
         } else {
           frappe.msgprint(
-            __(
-              "All active nurses are already in the schedule."
-            )
+            __("All active nurses are already in the schedule.")
           );
         }
       },

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -3,20 +3,34 @@
 
 frappe.ui.form.on("Nursing Schedule", {
   setup: function (frm) {
-    // Filter 'nurse' column in child table to only show Nurses
-    frm.set_query("nurse", "shifts", function () {
+    frm.trigger("set_query");
+  },
+
+  set_query: (frm) => {
+    frm.set_query("nurse", "assignments", function () {
       return {
         filters: {
+          status: 'Active',
           practitioner_role: "Nurse",
+          hms_tz_company: frm.doc.company,
         },
       };
     });
 
-    // Filter 'service_unit' and 'service_unit_type' correctly
-    frm.set_query("service_unit", "shifts", function () {
+    frm.set_query("service_unit_type", "assignments", function () {
+      return {
+        filters: {
+          disabled: 0,
+        },
+      };
+    });
+
+    frm.set_query("service_unit", "assignments", function () {
       return {
         filters: {
           is_group: 0,
+          disabled: 0,
+          company: frm.doc.company,
         },
       };
     });
@@ -28,6 +42,7 @@ frappe.ui.form.on("Nursing Schedule", {
 
   frequency: function (frm) {
     calculate_end_date(frm);
+    set_daily_assignment_dates(frm);
   },
 
   get_nurses: function (frm) {
@@ -47,37 +62,49 @@ frappe.ui.form.on("Nursing Schedule", {
       callback: function (r) {
         if (!r.message || r.message.length === 0) {
           frappe.msgprint(
-            __("No active nurses found for the selected company.")
+            __(
+              "No active nurses found for the selected company."
+            )
           );
           return;
         }
 
         // Collect existing nurse names to avoid duplicates
         const existing_nurses = new Set(
-          (frm.doc.shifts || []).map((row) => row.nurse)
+          (frm.doc.assignments || []).map(
+            (row) => row.nurse
+          )
         );
 
         let added_count = 0;
         r.message.forEach(function (nurse) {
           if (!existing_nurses.has(nurse.name)) {
-            let row = frm.add_child("shifts");
+            let row = frm.add_child("assignments");
             row.nurse = nurse.name;
             row.nurse_name = nurse.practitioner_name;
+            if (frm.doc.frequency === "Daily" && frm.doc.end_date) {
+              row.assignment_date = frm.doc.end_date;
+            }
             existing_nurses.add(nurse.name);
             added_count++;
           }
         });
 
-        frm.refresh_field("shifts");
+        frm.refresh_field("assignments");
 
         if (added_count > 0) {
           frappe.show_alert({
-            message: __("{0} nurse(s) added to the schedule.", [added_count]),
+            message: __(
+              "{0} nurse(s) added to the schedule.",
+              [added_count]
+            ),
             indicator: "green",
           });
         } else {
           frappe.msgprint(
-            __("All active nurses are already in the schedule.")
+            __(
+              "All active nurses are already in the schedule."
+            )
           );
         }
       },
@@ -86,15 +113,47 @@ frappe.ui.form.on("Nursing Schedule", {
 });
 
 frappe.ui.form.on("Nurse Schedule Detail", {
-  shift_based_on: function (frm, cdt, cdn) {
+  assignments_add: function (frm, cdt, cdn) {
+    if (frm.doc.frequency === "Daily" && frm.doc.end_date) {
+      frappe.model.set_value(
+        cdt,
+        cdn,
+        "assignment_date",
+        frm.doc.end_date
+      );
+    }
+  },
+
+  assign_based_on: function (frm, cdt, cdn) {
     let row = locals[cdt][cdn];
-    if (row.shift_based_on === "Service Unit") {
-      frappe.model.set_value(cdt, cdn, "service_unit_type", "");
+    if (row.assign_based_on === "Service Unit") {
+      frappe.model.set_value(
+        cdt,
+        cdn,
+        "service_unit_type",
+        ""
+      );
     } else {
       frappe.model.set_value(cdt, cdn, "service_unit", "");
     }
   },
 });
+
+function set_daily_assignment_dates(frm) {
+  if (frm.doc.frequency !== "Daily" || !frm.doc.end_date) return;
+
+  (frm.doc.assignments || []).forEach(function (row) {
+    if (!row.assignment_date) {
+      frappe.model.set_value(
+        row.doctype,
+        row.name,
+        "assignment_date",
+        frm.doc.end_date
+      );
+    }
+  });
+  frm.refresh_field("assignments");
+}
 
 function calculate_end_date(frm) {
   if (!frm.doc.start_date || !frm.doc.frequency) {
@@ -116,10 +175,16 @@ function calculate_end_date(frm) {
 
   let end_date;
   if (offset.days !== undefined) {
-    end_date = frappe.datetime.add_days(frm.doc.start_date, offset.days);
+    end_date = frappe.datetime.add_days(
+      frm.doc.start_date,
+      offset.days
+    );
   } else {
     // Add months, then subtract 1 day to get the last day of the period
-    end_date = frappe.datetime.add_months(frm.doc.start_date, offset.months);
+    end_date = frappe.datetime.add_months(
+      frm.doc.start_date,
+      offset.months
+    );
     end_date = frappe.datetime.add_days(end_date, -1);
   }
 

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.js
@@ -10,7 +10,7 @@ frappe.ui.form.on("Nursing Schedule", {
     frm.set_query("nurse", "assignments", function () {
       return {
         filters: {
-          status: 'Active',
+          status: "Active",
           practitioner_role: "Nurse",
           hms_tz_company: frm.doc.company,
         },
@@ -69,9 +69,7 @@ frappe.ui.form.on("Nursing Schedule", {
 
         // Collect existing nurse names to avoid duplicates
         const existing_nurses = new Set(
-          (frm.doc.assignments || []).map(
-            (row) => row.nurse
-          )
+          (frm.doc.assignments || []).map((row) => row.nurse)
         );
 
         let added_count = 0;
@@ -92,10 +90,7 @@ frappe.ui.form.on("Nursing Schedule", {
 
         if (added_count > 0) {
           frappe.show_alert({
-            message: __(
-              "{0} nurse(s) added to the schedule.",
-              [added_count]
-            ),
+            message: __("{0} nurse(s) added to the schedule.", [added_count]),
             indicator: "green",
           });
         } else {
@@ -111,24 +106,14 @@ frappe.ui.form.on("Nursing Schedule", {
 frappe.ui.form.on("Nurse Schedule Detail", {
   assignments_add: function (frm, cdt, cdn) {
     if (frm.doc.frequency === "Daily" && frm.doc.end_date) {
-      frappe.model.set_value(
-        cdt,
-        cdn,
-        "assignment_date",
-        frm.doc.end_date
-      );
+      frappe.model.set_value(cdt, cdn, "assignment_date", frm.doc.end_date);
     }
   },
 
   assign_based_on: function (frm, cdt, cdn) {
     let row = locals[cdt][cdn];
     if (row.assign_based_on === "Service Unit") {
-      frappe.model.set_value(
-        cdt,
-        cdn,
-        "service_unit_type",
-        ""
-      );
+      frappe.model.set_value(cdt, cdn, "service_unit_type", "");
     } else {
       frappe.model.set_value(cdt, cdn, "service_unit", "");
     }
@@ -171,16 +156,10 @@ function calculate_end_date(frm) {
 
   let end_date;
   if (offset.days !== undefined) {
-    end_date = frappe.datetime.add_days(
-      frm.doc.start_date,
-      offset.days
-    );
+    end_date = frappe.datetime.add_days(frm.doc.start_date, offset.days);
   } else {
     // Add months, then subtract 1 day to get the last day of the period
-    end_date = frappe.datetime.add_months(
-      frm.doc.start_date,
-      offset.months
-    );
+    end_date = frappe.datetime.add_months(frm.doc.start_date, offset.months);
     end_date = frappe.datetime.add_days(end_date, -1);
   }
 

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -56,6 +56,7 @@
             "fieldtype": "Date",
             "in_list_view": 1,
             "label": "End Date",
+            "read_only": 1,
             "reqd": 1
         },
         {
@@ -81,7 +82,7 @@
         }
     ],
     "links": [],
-    "modified": "2026-04-04 00:00:00.000000",
+    "modified": "2026-04-06 13:05:00.000000",
     "modified_by": "Administrator",
     "module": "Hms Tz",
     "name": "Nursing Schedule",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -12,9 +12,9 @@
         "column_break_01",
         "start_date",
         "end_date",
-        "section_break_shifts",
+        "section_break_assignments",
         "get_nurses",
-        "shifts",
+        "assignments",
         "amended_from"
     ],
     "fields": [
@@ -61,9 +61,9 @@
             "reqd": 1
         },
         {
-            "fieldname": "section_break_shifts",
+            "fieldname": "section_break_assignments",
             "fieldtype": "Section Break",
-            "label": "Shifts"
+            "label": "Assignments"
         },
         {
             "fieldname": "get_nurses",
@@ -72,9 +72,9 @@
             "depends_on": "eval:doc.company && doc.docstatus==0"
         },
         {
-            "fieldname": "shifts",
+            "fieldname": "assignments",
             "fieldtype": "Table",
-            "label": "Shifts",
+            "label": "Assignments",
             "options": "Nurse Schedule Detail",
             "reqd": 0
         },
@@ -89,7 +89,7 @@
         }
     ],
     "links": [],
-    "modified": "2026-04-06 13:05:00.000000",
+    "modified": "2026-04-06 17:30:00.000000",
     "modified_by": "Administrator",
     "module": "Hms Tz",
     "name": "Nursing Schedule",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -13,6 +13,7 @@
         "start_date",
         "end_date",
         "section_break_shifts",
+        "get_nurses",
         "shifts",
         "amended_from"
     ],
@@ -63,6 +64,12 @@
             "fieldname": "section_break_shifts",
             "fieldtype": "Section Break",
             "label": "Shifts"
+        },
+        {
+            "fieldname": "get_nurses",
+            "fieldtype": "Button",
+            "label": "Get Nurses",
+            "depends_on": "eval:doc.company && doc.docstatus==0"
         },
         {
             "fieldname": "shifts",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -1,0 +1,124 @@
+{
+    "actions": [],
+    "autoname": "naming_series:",
+    "creation": "2026-04-04 00:00:00.000000",
+    "doctype": "DocType",
+    "engine": "InnoDB",
+    "is_submittable": 1,
+    "field_order": [
+        "naming_series",
+        "company",
+        "frequency",
+        "column_break_01",
+        "start_date",
+        "end_date",
+        "section_break_shifts",
+        "shifts",
+        "amended_from"
+    ],
+    "fields": [
+        {
+            "fieldname": "naming_series",
+            "fieldtype": "Select",
+            "label": "Series",
+            "options": "NS-.YYYY.-",
+            "reqd": 1
+        },
+        {
+            "fieldname": "company",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "label": "Company",
+            "options": "Company",
+            "reqd": 1
+        },
+        {
+            "fieldname": "frequency",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "label": "Frequency",
+            "options": "Daily\nWeekly\nMonthly\nQuarterly\nBi-Yearly\nYearly",
+            "reqd": 1
+        },
+        {
+            "fieldname": "column_break_01",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "start_date",
+            "fieldtype": "Date",
+            "in_list_view": 1,
+            "label": "Start Date",
+            "reqd": 1
+        },
+        {
+            "fieldname": "end_date",
+            "fieldtype": "Date",
+            "in_list_view": 1,
+            "label": "End Date",
+            "reqd": 1
+        },
+        {
+            "fieldname": "section_break_shifts",
+            "fieldtype": "Section Break",
+            "label": "Shifts"
+        },
+        {
+            "fieldname": "shifts",
+            "fieldtype": "Table",
+            "label": "Shifts",
+            "options": "Nurse Schedule Detail",
+            "reqd": 0
+        },
+        {
+            "fieldname": "amended_from",
+            "fieldtype": "Link",
+            "label": "Amended From",
+            "options": "Nursing Schedule",
+            "no_copy": 1,
+            "print_hide": 1,
+            "read_only": 1
+        }
+    ],
+    "links": [],
+    "modified": "2026-04-04 00:00:00.000000",
+    "modified_by": "Administrator",
+    "module": "Hms Tz",
+    "name": "Nursing Schedule",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Healthcare Administrator",
+            "share": 1,
+            "write": 1,
+            "submit": 1,
+            "cancel": 1,
+            "amend": 1
+        },
+        {
+            "create": 1,
+            "delete": 0,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Nursing User",
+            "share": 1,
+            "write": 1,
+            "submit": 1,
+            "cancel": 1,
+            "amend": 1
+        }
+    ],
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "track_changes": 1
+}

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.json
@@ -13,6 +13,7 @@
         "start_date",
         "end_date",
         "section_break_shifts",
+        "get_nurses",
         "shifts",
         "amended_from"
     ],
@@ -56,12 +57,19 @@
             "fieldtype": "Date",
             "in_list_view": 1,
             "label": "End Date",
+            "read_only": 1,
             "reqd": 1
         },
         {
             "fieldname": "section_break_shifts",
             "fieldtype": "Section Break",
             "label": "Shifts"
+        },
+        {
+            "fieldname": "get_nurses",
+            "fieldtype": "Button",
+            "label": "Get Nurses",
+            "depends_on": "eval:doc.company && doc.docstatus==0"
         },
         {
             "fieldname": "shifts",
@@ -81,7 +89,7 @@
         }
     ],
     "links": [],
-    "modified": "2026-04-04 00:00:00.000000",
+    "modified": "2026-04-06 13:05:00.000000",
     "modified_by": "Administrator",
     "module": "Hms Tz",
     "name": "Nursing Schedule",

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -11,7 +11,7 @@ class NursingSchedule(Document):
     def validate(self):
         self.calculate_end_date()
         self.validate_dates()
-        self.validate_duplicate_nurse_shifts()
+        self.validate_duplicate_nurse_assignments()
 
     def calculate_end_date(self):
         """Auto-calculate end_date based on start_date and frequency."""
@@ -54,19 +54,24 @@ class NursingSchedule(Document):
                     title=_("Invalid Dates"),
                 )
 
-    def validate_duplicate_nurse_shifts(self):
-        """Warn if the same nurse appears in conflicting shifts in the same schedule."""
+    def validate_duplicate_nurse_assignments(self):
+        """Warn if the same nurse is assigned to the same location on the same date."""
         seen: dict = {}
-        for row in self.shifts or []:
-            # Check for same nurse, shift type, and assignment target
-            key = (row.nurse, row.shift_type, row.shift_based_on, row.service_unit if row.shift_based_on == 'Service Unit' else row.service_unit_type)
+        for row in self.assignments or []:
+            # Check for same nurse, date, and assignment target
+            location = (
+                row.service_unit
+                if row.assign_based_on == "Service Unit"
+                else row.service_unit_type
+            )
+            key = (row.nurse, row.assignment_date, row.assign_based_on, location)
             if key in seen:
                 frappe.throw(
                     _(
                         "Row #{0}: Nurse <b>{1}</b> is already assigned to the same "
-                        "shift/unit combination in Row #{2}."
+                        "location on the same date in Row #{2}."
                     ).format(row.idx, row.nurse, seen[key]),
-                    title=_("Duplicate Shift Assignment"),
+                    title=_("Duplicate Assignment"),
                 )
             seen[key] = row.idx
 

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -4,17 +4,49 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import add_to_date, getdate
 
 
 class NursingSchedule(Document):
     def validate(self):
+        self.calculate_end_date()
         self.validate_dates()
         self.validate_duplicate_nurse_shifts()
+
+    def calculate_end_date(self):
+        """Auto-calculate end_date based on start_date and frequency."""
+        if not self.start_date or not self.frequency:
+            return
+
+        frequency_map = {
+            "Daily": {"days": 0},
+            "Weekly": {"days": 6},
+            "Monthly": {"months": 1},
+            "Quarterly": {"months": 3},
+            "Bi-Yearly": {"months": 6},
+            "Yearly": {"years": 1},
+        }
+
+        offset = frequency_map.get(self.frequency)
+        if not offset:
+            return
+
+        if "days" in offset:
+            self.end_date = add_to_date(getdate(self.start_date), days=offset["days"])
+        elif "months" in offset:
+            # Add months, then subtract 1 day to get the last day of the period
+            self.end_date = add_to_date(
+                getdate(self.start_date), months=offset["months"], days=-1
+            )
+        elif "years" in offset:
+            self.end_date = add_to_date(
+                getdate(self.start_date), years=offset["years"], days=-1
+            )
 
     def validate_dates(self):
         """Ensure start_date is before or equal to end_date."""
         if self.start_date and self.end_date:
-            if self.start_date > self.end_date:
+            if getdate(self.start_date) > getdate(self.end_date):
                 frappe.throw(
                     _("Start Date {0} cannot be after End Date {1}").format(
                         frappe.bold(self.start_date), frappe.bold(self.end_date)
@@ -37,3 +69,26 @@ class NursingSchedule(Document):
                     title=_("Duplicate Shift Assignment"),
                 )
             seen[key] = row.idx
+
+
+@frappe.whitelist()
+def get_nurses(company: str) -> list[dict]:
+    """Return active nurses for the given company.
+
+    Filters Healthcare Practitioner records by:
+    - practitioner_role = 'Nurse'
+    - hms_tz_company = the provided company
+    - status = 'Active'
+    """
+    nurses = frappe.db.get_all(
+        "Healthcare Practitioner",
+        filters={
+            "practitioner_role": "Nurse",
+            "hms_tz_company": company,
+            "status": "Active",
+        },
+        fields=["name", "practitioner_name"],
+        order_by="practitioner_name asc",
+    )
+
+    return nurses

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, Aakvatech Limited and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class NursingSchedule(Document):
+    def validate(self):
+        self.validate_dates()
+        self.validate_duplicate_nurse_shifts()
+
+    def validate_dates(self):
+        """Ensure start_date is before or equal to end_date."""
+        if self.start_date and self.end_date:
+            if self.start_date > self.end_date:
+                frappe.throw(
+                    _("Start Date {0} cannot be after End Date {1}").format(
+                        frappe.bold(self.start_date), frappe.bold(self.end_date)
+                    ),
+                    title=_("Invalid Dates"),
+                )
+
+    def validate_duplicate_nurse_shifts(self):
+        """Warn if the same nurse appears in conflicting shifts in the same schedule."""
+        seen: dict = {}
+        for row in self.shifts or []:
+            # Check for same nurse, shift type, and assignment target
+            key = (row.nurse, row.shift_type, row.shift_based_on, row.service_unit if row.shift_based_on == 'Service Unit' else row.service_unit_type)
+            if key in seen:
+                frappe.throw(
+                    _(
+                        "Row #{0}: Nurse <b>{1}</b> is already assigned to the same "
+                        "shift/unit combination in Row #{2}."
+                    ).format(row.idx, row.nurse, seen[key]),
+                    title=_("Duplicate Shift Assignment"),
+                )
+            seen[key] = row.idx

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -4,17 +4,49 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import add_to_date, getdate
 
 
 class NursingSchedule(Document):
     def validate(self):
+        self.calculate_end_date()
         self.validate_dates()
         self.validate_duplicate_nurse_shifts()
+
+    def calculate_end_date(self):
+        """Auto-calculate end_date based on start_date and frequency."""
+        if not self.start_date or not self.frequency:
+            return
+
+        frequency_map = {
+            "Daily": {"days": 0},
+            "Weekly": {"days": 6},
+            "Monthly": {"months": 1},
+            "Quarterly": {"months": 3},
+            "Bi-Yearly": {"months": 6},
+            "Yearly": {"years": 1},
+        }
+
+        offset = frequency_map.get(self.frequency)
+        if not offset:
+            return
+
+        if "days" in offset:
+            self.end_date = add_to_date(getdate(self.start_date), days=offset["days"])
+        elif "months" in offset:
+            # Add months, then subtract 1 day to get the last day of the period
+            self.end_date = add_to_date(
+                getdate(self.start_date), months=offset["months"], days=-1
+            )
+        elif "years" in offset:
+            self.end_date = add_to_date(
+                getdate(self.start_date), years=offset["years"], days=-1
+            )
 
     def validate_dates(self):
         """Ensure start_date is before or equal to end_date."""
         if self.start_date and self.end_date:
-            if self.start_date > self.end_date:
+            if getdate(self.start_date) > getdate(self.end_date):
                 frappe.throw(
                     _("Start Date {0} cannot be after End Date {1}").format(
                         frappe.bold(self.start_date), frappe.bold(self.end_date)

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule.py
@@ -69,3 +69,26 @@ class NursingSchedule(Document):
                     title=_("Duplicate Shift Assignment"),
                 )
             seen[key] = row.idx
+
+
+@frappe.whitelist()
+def get_nurses(company: str) -> list[dict]:
+    """Return active nurses for the given company.
+
+    Filters Healthcare Practitioner records by:
+    - practitioner_role = 'Nurse'
+    - hms_tz_company = the provided company
+    - status = 'Active'
+    """
+    nurses = frappe.db.get_all(
+        "Healthcare Practitioner",
+        filters={
+            "practitioner_role": "Nurse",
+            "hms_tz_company": company,
+            "status": "Active",
+        },
+        fields=["name", "practitioner_name"],
+        order_by="practitioner_name asc",
+    )
+
+    return nurses

--- a/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule_list.js
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/nursing_schedule_list.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2026, Aakvatech Limited and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings["Nursing Schedule"] = {
+  onload: function (listview) {
+    listview.page.add_inner_button(__("Open Roster"), function () {
+      window.open("/frontend/nurse-roster");
+    });
+  },
+};

--- a/hms_tz/hms_tz/doctype/nursing_schedule/roster.py
+++ b/hms_tz/hms_tz/doctype/nursing_schedule/roster.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026, Aakvatech Limited and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.utils import add_to_date, getdate
+
+
+@frappe.whitelist()
+def get_roster_data(company: str, start_date: str, end_date: str) -> dict:
+    """Return nurses and their existing assignments for the given company and date range.
+
+    Returns:
+        dict with keys:
+        - nurses: list of {name, practitioner_name, employee}
+        - assignments: list of {nurse, assignment_date, assign_based_on,
+          service_unit_type, service_unit, parent, name}
+    """
+    if not company or not start_date or not end_date:
+        frappe.throw(_("Company, Start Date, and End Date are required."))
+
+    nurses = frappe.db.get_all(
+        "Healthcare Practitioner",
+        filters={
+            "practitioner_role": "Nurse",
+            "hms_tz_company": company,
+            "status": "Active",
+        },
+        fields=["name", "practitioner_name", "employee"],
+        order_by="practitioner_name asc",
+    )
+
+    nurse_names = [n.name for n in nurses]
+
+    # Get all assignments in the date range for these nurses
+    assignments = []
+    if nurse_names:
+        assignments = frappe.db.get_all(
+            "Nurse Schedule Detail",
+            filters={
+                "nurse": ["in", nurse_names],
+                "assignment_date": ["between", [start_date, end_date]],
+            },
+            fields=[
+                "name",
+                "parent",
+                "nurse",
+                "nurse_name",
+                "assignment_date",
+                "assign_based_on",
+                "service_unit_type",
+                "service_unit",
+            ],
+            order_by="assignment_date asc",
+        )
+
+    return {
+        "nurses": nurses,
+        "assignments": assignments,
+    }
+
+
+@frappe.whitelist()
+def save_roster_assignments(
+    company: str,
+    start_date: str,
+    end_date: str,
+    frequency: str,
+    assignments: list | str,
+) -> dict:
+    """Batch-save roster assignments.
+
+    Each assignment dict should have:
+    - nurse: str (Healthcare Practitioner name)
+    - assignment_date: str (YYYY-MM-DD)
+    - assign_based_on: str (Service Unit Type / Service Unit)
+    - service_unit_type: str (optional)
+    - service_unit: str (optional)
+    - existing_name: str (optional - if editing an existing row)
+    - action: str (add / edit / remove)
+
+    This function finds or creates Nursing Schedule documents for the
+    given company/start_date/end_date/frequency and updates their
+    child table rows accordingly.
+    """
+    import json
+
+    if isinstance(assignments, str):
+        assignments = json.loads(assignments)
+
+    if not assignments:
+        return {"message": _("No assignments to save.")}
+
+    # Find existing Nursing Schedule for this period, or create one
+    existing_schedule = frappe.db.get_value(
+        "Nursing Schedule",
+        filters={
+            "company": company,
+            "start_date": start_date,
+            "end_date": end_date,
+            "docstatus": ["!=", 2],
+        },
+        fieldname="name",
+    )
+
+    if existing_schedule:
+        schedule = frappe.get_doc("Nursing Schedule", existing_schedule)
+    else:
+        schedule = frappe.new_doc("Nursing Schedule")
+        schedule.company = company
+        schedule.frequency = frequency
+        schedule.start_date = start_date
+        schedule.end_date = end_date
+
+    for assignment in assignments:
+        action = assignment.get("action", "add")
+        existing_name = assignment.get("existing_name")
+
+        if action == "remove" and existing_name:
+            # Remove the row from the child table
+            schedule.assignments = [
+                row for row in schedule.assignments if row.name != existing_name
+            ]
+            continue
+
+        if action == "edit" and existing_name:
+            # Find and update the existing row
+            for row in schedule.assignments:
+                if row.name == existing_name:
+                    row.assign_based_on = assignment.get("assign_based_on", "")
+                    row.service_unit_type = assignment.get("service_unit_type", "")
+                    row.service_unit = assignment.get("service_unit", "")
+                    break
+            continue
+
+        # action == "add"
+        # Validate: no duplicate nurse + date
+        duplicate = False
+        for row in schedule.assignments:
+            if (
+                row.nurse == assignment.get("nurse")
+                and str(row.assignment_date) == str(assignment.get("assignment_date"))
+            ):
+                duplicate = True
+                break
+
+        if duplicate:
+            frappe.msgprint(
+                _("Nurse {0} already has an assignment on {1}. Skipping.").format(
+                    assignment.get("nurse"), assignment.get("assignment_date")
+                ),
+                alert=True,
+            )
+            continue
+
+        schedule.append(
+            "assignments",
+            {
+                "nurse": assignment.get("nurse"),
+                "assignment_date": assignment.get("assignment_date"),
+                "assign_based_on": assignment.get("assign_based_on", "Service Unit Type"),
+                "service_unit_type": assignment.get("service_unit_type", ""),
+                "service_unit": assignment.get("service_unit", ""),
+            },
+        )
+
+    schedule.save(ignore_permissions=False)
+
+    return {
+        "message": _("Roster saved successfully."),
+        "schedule_name": schedule.name,
+    }
+
+
+@frappe.whitelist()
+def get_service_options(company: str) -> dict:
+    """Return service unit types and service units for dropdowns."""
+    service_unit_types = frappe.db.get_all(
+        "Healthcare Service Unit Type",
+        filters={"disabled": 0},
+        fields=["name"],
+        order_by="name asc",
+    )
+
+    service_units = frappe.db.get_all(
+        "Healthcare Service Unit",
+        filters={"is_group": 0, "disabled": 0, "company": company},
+        fields=["name", "service_unit_type"],
+        order_by="name asc",
+    )
+
+    return {
+        "service_unit_types": [s.name for s in service_unit_types],
+        "service_units": [{"name": s.name, "type": s.service_unit_type} for s in service_units],
+    }

--- a/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.js
+++ b/hms_tz/hms_tz/doctype/patient_appointment/patient_appointment.js
@@ -29,6 +29,7 @@ frappe.ui.form.on("Patient Appointment", {
       return {
         filters: {
           department: frm.doc.department,
+          practitioner_role: "Doctor",
         },
       };
     });
@@ -54,12 +55,14 @@ frappe.ui.form.on("Patient Appointment", {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/patient_encounter/patient_encounter.js
+++ b/hms_tz/hms_tz/doctype/patient_encounter/patient_encounter.js
@@ -145,17 +145,27 @@ frappe.ui.form.on("Patient Encounter", {
       };
     });
 
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
+
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }
@@ -805,6 +815,7 @@ var refer_practitioner = function (frm) {
         return {
           filters: {
             department: selected_department,
+            practitioner_role: "Doctor",
           },
         };
       };

--- a/hms_tz/hms_tz/doctype/patient_referral/patient_referral.js
+++ b/hms_tz/hms_tz/doctype/patient_referral/patient_referral.js
@@ -2,6 +2,14 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Patient Referral", {
+  setup: function (frm) {
+    frm.set_query("referred_to_practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     if (!frm.doc.__islocal) {
       if (frm.doc.status == "Pending" && frm.doc.docstatus == 1) {

--- a/hms_tz/hms_tz/doctype/practitioner_availability/practitioner_availability.js
+++ b/hms_tz/hms_tz/doctype/practitioner_availability/practitioner_availability.js
@@ -2,6 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Practitioner Availability", {
+  setup: function (frm) {
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     set_event_type_properties_to_event(frm);
     frm.set_query("service_unit", function () {

--- a/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.js
+++ b/hms_tz/hms_tz/doctype/radiology_examination/radiology_examination.js
@@ -219,17 +219,26 @@ frappe.ui.form.on("Radiology Examination", {
         },
       };
     });
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/hms_tz/doctype/therapy_session/therapy_session.js
+++ b/hms_tz/hms_tz/doctype/therapy_session/therapy_session.js
@@ -95,17 +95,26 @@ frappe.ui.form.on("Therapy Session", {
       );
     }
 
+    frm.set_query("practitioner", function () {
+      return {
+        filters: {
+          practitioner_role: "Doctor",
+        },
+      };
+    });
     frm.set_query("referring_practitioner", function () {
       if (frm.doc.source == "External Referral") {
         return {
           filters: {
             healthcare_practitioner_type: "External",
+            practitioner_role: "Doctor",
           },
         };
       } else {
         return {
           filters: {
             healthcare_practitioner_type: "Internal",
+            practitioner_role: "Doctor",
           },
         };
       }

--- a/hms_tz/nhif/api/clinical_procedure.js
+++ b/hms_tz/nhif/api/clinical_procedure.js
@@ -1,4 +1,9 @@
 frappe.ui.form.on("Clinical Procedure", {
+  setup: function (frm) {
+    frm.set_query("practitioner", function () {
+      return { filters: { practitioner_role: "Doctor" } };
+    });
+  },
   refresh: function (frm) {
     $('[data-label="Not%20Serviced"]').parent().hide();
     frm.remove_custom_button("Start");

--- a/hms_tz/nhif/api/patient_appointment.js
+++ b/hms_tz/nhif/api/patient_appointment.js
@@ -760,6 +760,7 @@ const check_and_set_availability = (frm) => {
               filters: {
                 status: "Active",
                 hms_tz_company: frm.doc.company,
+                practitioner_role: "Doctor",
               },
             };
           },

--- a/hms_tz/nhif/report/monthly_nhif_detail/monthly_nhif_detail.py
+++ b/hms_tz/nhif/report/monthly_nhif_detail/monthly_nhif_detail.py
@@ -2,6 +2,11 @@ import frappe
 from frappe import _
 from frappe.query_builder import DocType
 
+hsr = DocType("Healthcare Service Request")
+hsrp = DocType("Healthcare Service Request Payment")
+pa = DocType("Patient Appointment")
+io = DocType("Inpatient Occupancy")
+ic = DocType("Inpatient Consultancy")
 
 def execute(filters):
     columns = get_columns()
@@ -124,99 +129,121 @@ def process_merged_items(raw_data):
             for name in str(row.get("ref_docname") or "").split(",")
             if name.strip()
         ]
-        ref_doctype = row.get("service_type")
-        coverage_plan_name = row.get("coverage_plan_name") or ""
-        item_code = row.get("item_code") or ""
-        details_map = get_hsr_details_batch(
-            ref_docname_list, ref_doctype, coverage_plan_name, item_code
+        ref_doclist = get_hsr_details_batch(
+            ref_docname_list,
+            row.get("service_type"),
+            row.get("coverage_plan_name"),
+            row.get("item_code"),
+            row.get("patient_appointment")
         )
 
-        if len(ref_docname_list) > 1:
-            # Merged items - create a separate row for each ref_docname
-            for ref_docname in ref_docname_list:
-                hsr_details = details_map.get(ref_docname, {})
-                new_row = row.copy()
-                new_row["qty"] = hsr_details.get("qty", 0)
-                new_row["amount_claimed"] = hsr_details.get("amount", 0)
-                new_row["practitioner"] = hsr_details.get("practitioner")
-                new_row.pop("ref_docname", None)
-                new_row.pop("item_code", None)
-                new_row.pop("coverage_plan_name", None)
-                processed_data.append(new_row)
-        else:
-            # Single item - get practitioner from Healthcare Service Request
-            ref_docname = ref_docname_list[0] if ref_docname_list else ""
-            hsr_details = details_map.get(ref_docname, {})
-            row["practitioner"] = hsr_details.get("practitioner")
-            row.pop("ref_docname", None)
-            row.pop("item_code", None)
-            row.pop("coverage_plan_name", None)
-            processed_data.append(row)
+        for ref_doc in ref_doclist:
+            new_row = row.copy()
+            new_row["qty"] = ref_doc.get("qty", 0)
+            new_row["amount_claimed"] = ref_doc.get("amount", 0)
+            new_row["practitioner"] = ref_doc.get("practitioner")
+            new_row["patient_appointment"] = ref_doc.get("patient_appointment")
+            new_row.pop("ref_docname", None)
+            new_row.pop("item_code", None)
+            new_row.pop("coverage_plan_name", None)
+            processed_data.append(new_row)
 
     return processed_data
 
 
-def get_hsr_details_batch(ref_docname_list, ref_doctype, coverage_plan_name, item_code):
+def get_hsr_details_batch(ref_docname_list, ref_doctype, coverage_plan_name, item_code, appointment):
     """
     Fetch qty, amount, and practitioner for multiple ref_docnames in a single query
     by joining Healthcare Service Request Payment with its parent.
-    Returns a dict keyed by ref_docname.
+    Returns a list of dicts with qty, amount, practitioner, and patient_appointment.
     """
     if not ref_docname_list:
-        return {}
+        return []
 
-    hsr = DocType("Healthcare Service Request")
-    hsrp = DocType("Healthcare Service Request Payment")
+    ref_doclist = []
 
-    results = (
-        frappe.qb.from_(hsrp)
-        .inner_join(hsr)
-        .on(hsrp.parent == hsr.name)
-        .select(
-            hsrp.ref_docname,
-            (hsrp.qty - hsrp.qty_returned).as_("qty"),
-            hsrp.amount,
-            hsr.practitioner,
-        )
-        .where(
-            (hsrp.ref_docname.isin(ref_docname_list))
-            & (hsrp.ref_doctype == ref_doctype)
-            & (hsrp.payor_plan == coverage_plan_name)
-            & (hsrp.item_code == item_code)
-        )
-        .run(as_dict=True)
-    )
-
-    details_map = {}
-    for r in results:
-        details_map[r.ref_docname] = {
-            "qty": r.get("qty", 0),
-            "amount": r.get("amount", 0),
-            "practitioner": r.get("practitioner"),
-        }
-
-    # For Patient Appointment, batch fetch practitioners from the appointments
     if ref_doctype == "Patient Appointment":
-        pa = DocType("Patient Appointment")
         pa_results = (
             frappe.qb.from_(pa)
-            .select(pa.name, pa.practitioner)
+            .select(
+                pa.name,
+                pa.paid_amount,
+                pa.practitioner
+            )
             .where(pa.name.isin(ref_docname_list))
             .run(as_dict=True)
         )
-        pa_map = {r.name: r.practitioner for r in pa_results}
-        for name in ref_docname_list:
-            if name in details_map:
-                details_map[name]["practitioner"] = pa_map.get(name) or details_map[name]["practitioner"]
-            else:
-                details_map[name] = {"qty": 1, "amount": 0, "practitioner": pa_map.get(name)}
+        for r in pa_results:
+            ref_doclist.append({
+                "qty": 1,
+                "amount": r.get("paid_amount", 0),
+                "practitioner": r.get("practitioner"),
+                "patient_appointment": r.name,
+            })
+    elif ref_doctype == "Inpatient Occupancy":
+        io_results = (
+            frappe.qb.from_(io)
+            .select(
+                io.name,
+                io.amount,
+            )
+            .where(io.name.isin(ref_docname_list))
+            .run(as_dict=True)
+        )
+        for r in io_results:
+            ref_doclist.append({
+                "qty": 1,
+                "amount": r.get("amount", 0),
+                "patient_appointment": appointment
+            })
+    elif ref_doctype == "Inpatient Consultancy":
+        ic_results = (
+            frappe.qb.from_(ic)
+            .select(
+                ic.name,
+                ic.rate,
+                ic.healthcare_practitioner
+            )
+            .where(ic.name.isin(ref_docname_list))
+            .run(as_dict=True)
+        )
+        for r in ic_results:
+            ref_doclist.append({
+                "qty": 1,
+                "amount": r.get("rate", 0),
+                "practitioner": r.get("healthcare_practitioner"),
+                "patient_appointment": appointment
+            })
+    else:
+        results = (
+            frappe.qb.from_(hsrp)
+            .inner_join(hsr)
+            .on(hsrp.parent == hsr.name)
+            .select(
+                hsrp.ref_docname,
+                (hsrp.qty - hsrp.qty_returned).as_("qty"),
+                hsrp.amount,
+                hsr.practitioner,
+                hsr.appointment
+            )
+            .where(
+                (hsrp.ref_docname.isin(ref_docname_list))
+                & (hsrp.ref_doctype == ref_doctype)
+                & (hsrp.payor_plan == coverage_plan_name)
+                & (hsrp.item_code == item_code)
+            )
+            .run(as_dict=True)
+        )
 
-    # Fill defaults for any ref_docnames not found
-    for name in ref_docname_list:
-        if name not in details_map:
-            details_map[name] = {"qty": 1, "amount": 0, "practitioner": None}
+        for r in results:
+            ref_doclist.append({
+                "qty": r.get("qty", 0),
+                "amount": r.get("amount", 0),
+                "practitioner": r.get("practitioner"),
+                "patient_appointment": r.get("appointment") 
+            })
 
-    return details_map
+    return ref_doclist
 
 
 def get_data(filters):
@@ -260,57 +287,7 @@ def get_data(filters):
 
     raw_data = data_query.run(as_dict=True)
 
-    # Process data to handle merged items and add practitioner information
     processed_data = process_merged_items(raw_data)
 
     return processed_data
 
-
-# SELECT
-#     npc.name AS "NHIF Patient Claim:Link/NHIF Patient Claim:",
-#     npc.patient AS "Patient:Link/Patient:150",
-#     npc.patient_name AS "Patient Name:Data:",
-#     npc.patient_appointment AS "Patient Appointment:Link/Patient Appointment:150",
-#     npci.ref_doctype AS "Service Type:Data:",
-#     npci.item_name,
-#     npc.gender AS "Gender::",
-#     npc.attendance_date AS "Appointment Date:Date:",
-#     npc.date_discharge AS "Discharge Date:Date:",
-#    SUM(npci.amount_claimed) AS "Amount Claimed:Currency:",
-#    SUM(npci.item_quantity) AS "Total Quantity:Int:",
-#    npc.folio_no AS "Folio No::"
-# FROM `tabNHIF Patient Claim` npc
-# INNER JOIN `tabNHIF Patient Claim Item` npci ON npc.name = npci.parent
-# WHERE npc.docstatus = 1
-#   AND npc.claim_month = %(claim_month)s
-#   AND npc.claim_year = %(claim_year)s
-#   AND npc.company = %(company)s
-# GROUP BY npc.patient, npc.patient_appointment, npci.ref_doctype,
-# npci.item_name, npc.gender,npc.attendance_date, npc.date_discharge
-
-
-# "filters": [
-#     {
-#         "fieldname": "claim_month",
-#         "fieldtype": "Int",
-#         "label": "Claim Month",
-#         "mandatory": 1,
-#         "wildcard_filter": 0
-#     },
-#     {
-#         "fieldname": "claim_year",
-#         "fieldtype": "Int",
-#         "label": "Claim Year",
-#         "mandatory": 1,
-#         "wildcard_filter": 0
-#     },
-#     {
-#         "fieldname": "company",
-#         "fieldtype": "Link",
-#         "label": "Company",
-#         "mandatory": 1,
-#         "options": "Company",
-#         "wildcard_filter": 0
-#     }
-# ],
-# "query": "SELECT\n    npc.name AS \"NHIF Patient Claim:Link/NHIF Patient Claim:\",\n    npc.patient AS \"Patient:Link/Patient:150\",\n    npc.patient_name AS \"Patient Name:Data:\",\n    npc.patient_appointment AS \"Patient Appointment:Link/Patient Appointment:150\",\n    npci.ref_doctype AS \"Service Type:Data:\",\n    npci.item_name,\n    npc.gender AS \"Gender::\",\n    npc.attendance_date AS \"Appointment Date:Date:\",\n    npc.date_discharge AS \"Discharge Date:Date:\",\n   SUM(npci.amount_claimed) AS \"Amount Claimed:Currency:\",\n   SUM(npci.item_quantity) AS \"Total Quantity:Int:\",\n   npc.folio_no AS \"Folio No::\"\nFROM `tabNHIF Patient Claim` npc\nINNER JOIN `tabNHIF Patient Claim Item` npci ON npc.name = npci.parent\nWHERE npc.docstatus = 1\n  AND npc.claim_month = %(claim_month)s\n  AND npc.claim_year = %(claim_year)s\n  AND npc.company = %(company)s\nGROUP BY npc.patient, npc.patient_appointment, npci.ref_doctype, npci.item_name, npc.gender,npc.attendance_date, npc.date_discharge",

--- a/hms_tz/patches/custom_fields/custom_fields_json/28_healthcare_practitioner_nursing.json
+++ b/hms_tz/patches/custom_fields/custom_fields_json/28_healthcare_practitioner_nursing.json
@@ -1,0 +1,32 @@
+[
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "practitioner_role",
+        "fieldtype": "Select",
+        "label": "Practitioner Role",
+        "options": "Doctor\nNurse\nOther",
+        "insert_after": "healthcare_practitioner_type",
+        "reqd": 1,
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "nursing_specialization",
+        "fieldtype": "Select",
+        "label": "Nursing Specialization",
+        "options": "\nGeneral Nursing\nCritical Care (ICU)\nSurgical/Theater\nMidwifery\nPediatric\nEmergency",
+        "depends_on": "eval:doc.practitioner_role==\"Nurse\"",
+        "insert_after": "practitioner_role",
+        "doctype": "Custom Field"
+    },
+    {
+        "dt": "Healthcare Practitioner",
+        "fieldname": "nursing_role",
+        "fieldtype": "Select",
+        "label": "Nursing Role",
+        "options": "\nStaff Nurse\nCharge Nurse\nNurse Manager",
+        "depends_on": "eval:doc.practitioner_role==\"Nurse\"",
+        "insert_after": "nursing_specialization",
+        "doctype": "Custom Field"
+    }
+]

--- a/hms_tz/patches/property_setter/property_setters_json/27_healthcare_practitioner_nursing.json
+++ b/hms_tz/patches/property_setter/property_setters_json/27_healthcare_practitioner_nursing.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "Healthcare Practitioner-employee-mandatory_depends_on",
+        "owner": "Administrator",
+        "creation": "2026-04-06 17:30:00.000000",
+        "modified": "2026-04-06 17:30:00.000000",
+        "modified_by": "Administrator",
+        "docstatus": 0,
+        "idx": 0,
+        "is_system_generated": 0,
+        "doctype_or_field": "DocField",
+        "doc_type": "Healthcare Practitioner",
+        "field_name": "employee",
+        "property": "mandatory_depends_on",
+        "property_type": "Data",
+        "value": "eval:doc.practitioner_role=='Nurse'",
+        "doctype": "Property Setter"
+    }
+]


### PR DESCRIPTION
## Nurse Roster SPA (Task 6 - Design A)

### Summary
Implements the Nurse Roster single-page application for managing nurse-to-ward/room assignments across dates. This is a complete frontend + backend feature built with Vue 3 (Composition API), Pinia, and Frappe UI.

### Backend (roster.py)
- `get_roster_data`: Fetches nurses (by company) and their schedule assignments for a date range
- `get_service_options`: Returns service unit types and service units for dropdown population
- `save_roster_assignments`: Batch processes add/edit/remove roster changes against Nursing Schedule documents
- `nursing_schedule_list.js`: Adds "Open Roster" button to Nursing Schedule list view

### Frontend SPA
- **Layout**: CRM-style collapsible sidebar with Nurse Roster (active) and Nursing Schedule navigation
- **Auto-load**: Roster auto-loads when all filter fields (Company, Frequency, Start Date, End Date) are populated — no button needed
- **Centered UI**: Title, subtitle (light blue), and filter fields are centered
- **Field order**: Company → Frequency → Start Date → End Date (auto-calculated from frequency)
- **Assignment Dialog**: Clean Dialog component with searchable Autocomplete fields for Service Unit Type and Service Unit (handles 100+ options)
- **Past Date Protection**: No edit icon or dialog for backdated assignments; past assignments retain same blue pill styling as current/future dates
- **Pending Changes**: Save/Discard bar tracks unsaved changes before committing to server
- **State Management**: Pinia store (`rosterStore.js`) centralizes filter state, data, and API calls

### Testing
- Site: `neph` at `http://neph:8001/frontend/nurse-roster`
- Verified: auto-load, past date locking, dialog assignment, searchable dropdowns, sidebar order